### PR TITLE
Handle decoding errors gracefully

### DIFF
--- a/multicall/multicall_test.go
+++ b/multicall/multicall_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/alethio/web3-go/ethrpc"
 	"github.com/alethio/web3-go/ethrpc/provider/httprpc"
 	"github.com/alethio/web3-multicall-go/multicall"
+	"github.com/stretchr/testify/assert"
 	"testing"
 	"time"
 )
@@ -31,6 +32,35 @@ func TestExampleViwCall(t *testing.T) {
 	fmt.Println(res)
 	fmt.Println(err)
 
+}
+
+func TestViwCallWithDecodeError(t *testing.T) {
+	eth, err := getETH("https://mainnet.infura.io/v3/17ed7fe26d014e5b9be7dfff5368c69d")
+	vc1 := multicall.NewViewCall(
+		"good_call",
+		"0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
+		"symbol()(string)",
+		[]interface{}{},
+	)
+	vc2 := multicall.NewViewCall(
+		"broken_call",
+		"0xa417221ef64b1549575c977764e651c9fab50141",
+		"latestAnswer()(int256)",
+		[]interface{}{},
+	)
+
+	vcs := multicall.ViewCalls{vc1, vc2}
+	mc, _ := multicall.New(eth)
+	block := "latest"
+	res, err := mc.Call(vcs, block)
+	if err != nil {
+		panic(err)
+	}
+
+	assert.Equal(t, true, res.Calls["good_call"].Success)
+	assert.Equal(t, "UNI", res.Calls["good_call"].Decoded[0].(string))
+
+	assert.Equal(t, false, res.Calls["broken_call"].Success)
 }
 
 func getETH(url string) (ethrpc.ETHInterface, error) {

--- a/multicall/options.go
+++ b/multicall/options.go
@@ -6,7 +6,7 @@ type Option func(*Config)
 
 type Config struct {
 	MulticallAddress string
-	Gas				 string
+	Gas              string
 }
 
 const (
@@ -15,7 +15,6 @@ const (
 	// RopstenMulticall : Multicall contract address on Ropsten
 	RopstenAddress = "0xf3ad7e31b052ff96566eedd218a823430e74b406"
 )
-
 
 func ContractAddress(address string) Option {
 	return func(c *Config) {

--- a/multicall/viewcall.go
+++ b/multicall/viewcall.go
@@ -311,7 +311,7 @@ func (calls ViewCalls) decode(raw string) (*Result, error) {
 		if decoded.Returns[index].Success {
 			returnValues, err := call.decode(decoded.Returns[index].Data)
 			if err != nil {
-				return nil, err
+				callResult.Success = false
 			}
 			callResult.Decoded = returnValues
 		}


### PR DESCRIPTION
**Description**: Decoding errors on sub-calls should not break the entire multicall.

**Current behavior:** a single decoding error on a sub-call results in the whole multicall breaking, returning an error.

**Proposed behavior:** a single decoding error on a sub-call will mark the sub-call as failed, without impacting all other calls.

Decoding errors can happen for a variety of reasons, for example if Geth doesn't return any data. I added a test with two calls to demonstrate the new behavior, where the broken calls is targeting a contract that [self-distructed](https://etherscan.io/address/0xA417221ef64b1549575C977764E651c9FAB50141).

PS thanks for open sourcing this! 🙏 